### PR TITLE
Scanned ApiDocumentationController is not excluded in the processControllers method

### DIFF
--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -76,7 +76,7 @@ public class ApiParserImpl implements ApiParser {
     private Map<String, Documentation> processControllers(Set<Class<?>> controllerClasses) {
         //Loop over end points (controllers)
         for (Class<?> controllerClass : controllerClasses) {
-            if (controllerClass.isAssignableFrom(ApiDocumentationController.class)) {
+            if (ApiDocumentationController.class.isAssignableFrom(controllerClass)) {
                 continue;
             }
 


### PR DESCRIPTION
The JavaDoc for isAssignableFrom states :
Determines if the class or interface represented by this
- {@code Class} object is either the same as, or is a superclass or
- superinterface of, the class or interface represented by the specified
- {@code Class} parameter.

x.isAssignableFrom(y) -> is x >= y ?
so in our check y should be the scanned controller class and x the ApiDocumentClass,
otherwise the current check will only exclude ApiDocumentClass or classes ApiDocumentClass extends
