### PR TITLE
Excluding an API

### DIFF
--- a/src/main/java/com/knappsack/swagger4springweb/annotation/ApiExclude.java
+++ b/src/main/java/com/knappsack/swagger4springweb/annotation/ApiExclude.java
@@ -1,0 +1,17 @@
+package com.knappsack.swagger4springweb.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation which indicates if this Api should be excluded from the
+ * automatically generated swagger documents
+ *
+ * This annotation is applicable to the controller class or a method inside the controller
+ */
+@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface ApiExclude {
+}

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -1,5 +1,6 @@
 package com.knappsack.swagger4springweb.parser;
 
+import com.knappsack.swagger4springweb.annotation.ApiExclude;
 import com.knappsack.swagger4springweb.controller.ApiDocumentationController;
 import com.knappsack.swagger4springweb.util.AnnotationUtils;
 import com.wordnik.swagger.annotations.Api;
@@ -80,6 +81,10 @@ public class ApiParserImpl implements ApiParser {
                 continue;
             }
 
+            if (controllerClass.isAnnotationPresent(ApiExclude.class)) {
+                continue;
+            }
+
             Documentation documentation = processControllerDocumentation(controllerClass);
             String description = "";
             Api controllerApi = controllerClass.getAnnotation(Api.class);
@@ -94,7 +99,10 @@ public class ApiParserImpl implements ApiParser {
                 createDocumentationSchemas(documentation);
             }
 
-            documents.put(documentation.getResourcePath(), documentation);
+            // controllers without any operations are excluded from the documents list
+            if (documentation.getApis() != null && !documentation.getApis().isEmpty()) {
+                documents.put(documentation.getResourcePath(), documentation);
+            }
         }
 
         return documents;
@@ -130,6 +138,10 @@ public class ApiParserImpl implements ApiParser {
         populateEndpointMapForDocumentation(documentation, endPointMap);
         
         for (Method method : methods) {
+            if (method.isAnnotationPresent(ApiExclude.class)) {
+                continue;
+            }
+
             String requestMappingValue = AnnotationUtils.getMethodRequestMappingValue(method);
             DocumentationEndPointParser documentationEndPointParser = new DocumentationEndPointParser();
             DocumentationEndPoint documentationEndPoint = documentationEndPointParser.getDocumentationEndPoint(method, description, documentation.getResourcePath());
@@ -140,6 +152,10 @@ public class ApiParserImpl implements ApiParser {
         }
 
         for (Method method : methods) {
+            if (method.isAnnotationPresent(ApiExclude.class)) {
+                continue;
+            }
+
             String value = AnnotationUtils.getMethodRequestMappingValue(method);
             DocumentationEndPoint documentationEndPoint = endPointMap.get(value);
 

--- a/src/test/java/com/knappsack/swagger4springweb/AbstractTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/AbstractTest.java
@@ -1,19 +1,11 @@
 package com.knappsack.swagger4springweb;
 
-import org.reflections.Reflections;
-import org.springframework.stereotype.Controller;
-
-import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class AbstractTest {
-
     public static final String BASE_CONTROLLER_PACKAGE = "com.knappsack.swagger4springweb.testController";
     public static final String BASE_MODEL_PACKAGE = "com.knappsack.swagger4springweb.testModels";
-
-    public Class getControllerClass() {
-        Reflections reflections = new Reflections(BASE_CONTROLLER_PACKAGE);
-        Set<Class<?>> controllerClasses = reflections.getTypesAnnotatedWith(Controller.class);
-
-        return controllerClasses.iterator().next();
-    }
+    public static final String EXCLUDE_LABEL = "exclude";
+    public static final List<String> END_POINT_PATHS = Arrays.asList("/api/doc/api/v1/partialExclude", "/api/doc/api/v1/test");
 }

--- a/src/test/java/com/knappsack/swagger4springweb/AnnotationUtilsTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/AnnotationUtilsTest.java
@@ -1,13 +1,13 @@
 package com.knappsack.swagger4springweb;
 
 import com.knappsack.swagger4springweb.model.AnnotatedParameter;
+import com.knappsack.swagger4springweb.testController.TestController;
 import com.knappsack.swagger4springweb.util.AnnotationUtils;
 import com.wordnik.swagger.annotations.ApiParam;
 import org.junit.Test;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -20,7 +20,7 @@ public class AnnotationUtilsTest extends AbstractTest {
 
     @Test
     public void testHasApiParam() {
-        Class controllerClass = getControllerClass();
+        Class controllerClass = TestController.class;
         try {
             boolean hasApiParam = AnnotationUtils.hasApiParam(controllerClass.getMethod("getTestPojos", HttpServletRequest.class, String.class));
             assertTrue(hasApiParam);
@@ -31,7 +31,7 @@ public class AnnotationUtilsTest extends AbstractTest {
 
     @Test
     public void testGetMethodRequestMappingValue() {
-        Class controllerClass = getControllerClass();
+        Class controllerClass = TestController.class;
         try {
             String requestMappingValue = AnnotationUtils.getMethodRequestMappingValue(controllerClass.getMethod("getTestPojos", HttpServletRequest.class, String.class));
             assertEquals(requestMappingValue, "");
@@ -42,7 +42,7 @@ public class AnnotationUtilsTest extends AbstractTest {
 
     @Test
     public void testGetSwaggerParameterAnnotations() throws NoSuchMethodException {
-        Class controllerClass = getControllerClass();
+        Class controllerClass = TestController.class;
         Method method = controllerClass.getMethod("getTestPojos", HttpServletRequest.class, String.class);
         List<AnnotatedParameter> annotatedParameters = AnnotationUtils.getAnnotatedParameters(method);
         assertTrue(annotatedParameters.size() == 1);
@@ -55,7 +55,7 @@ public class AnnotationUtilsTest extends AbstractTest {
 
     @Test
     public void testGetSpringMvcParaterAnnotations() throws NoSuchMethodException {
-        Class controllerClass = getControllerClass();
+        Class controllerClass = TestController.class;
         Method method = controllerClass.getMethod("getTestPojosNoSwaggerAnnotations", HttpServletRequest.class, String.class);
         List<AnnotatedParameter> annotatedParameters = AnnotationUtils.getAnnotatedParameters(method);
         assertTrue(annotatedParameters.size() == 1);
@@ -78,7 +78,7 @@ public class AnnotationUtilsTest extends AbstractTest {
 
 	@Test
     public void testMethodHasNoApiParamAnnotation() throws NoSuchMethodException {
-        Class controllerClass = getControllerClass();
+        Class controllerClass = TestController.class;
         Method method = controllerClass.getMethod("getTestPojosNoSwaggerAnnotations", HttpServletRequest.class, String.class);
         boolean hasApiParam = AnnotationUtils.hasApiParam(method);
         assertFalse(hasApiParam);

--- a/src/test/java/com/knappsack/swagger4springweb/ApiParserTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiParserTest.java
@@ -5,26 +5,25 @@ import com.knappsack.swagger4springweb.parser.ApiParser;
 import com.knappsack.swagger4springweb.parser.ApiParserImpl;
 import com.wordnik.swagger.core.Documentation;
 import com.wordnik.swagger.core.DocumentationEndPoint;
+import com.wordnik.swagger.core.DocumentationOperation;
 import com.wordnik.swagger.core.SwaggerSpec;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ApiParserTest extends AbstractTest {
-
     @Test
     public void testParseControllerDocumentation() {
-        List<String> controllerPackage = new ArrayList<String>();
-        controllerPackage.add(BASE_CONTROLLER_PACKAGE);
-        List<String> modelPackage = new ArrayList<String>();
-        modelPackage.add(BASE_MODEL_PACKAGE);
-        ApiParser apiParser = new ApiParserImpl(controllerPackage, modelPackage, "http://localhost:8080/api", "/api", "v1", new ArrayList<String>());
-        Map<String, Documentation> documentList = apiParser.createDocuments();
+        Map<String, Documentation> documentList = createApiParser().createDocuments();
         for (String key : documentList.keySet()) {
             Documentation documentation = documentList.get(key);
             ObjectMapper mapper = new ObjectMapper();
@@ -42,21 +41,42 @@ public class ApiParserTest extends AbstractTest {
         }
     }
 
+    @Test
+    public void testOperationApiExclude() {
+        ApiParser apiParser = createApiParser();
+        Map<String, Documentation> documents = apiParser.createDocuments();
+
+        // validate that we don't expose any excluded operations in the documents
+        for (Documentation documentation : documents.values()) {
+            for (DocumentationEndPoint api : documentation.getApis()) {
+                for (DocumentationOperation op : api.getOperations()) {
+                    assertFalse("The operation " + op.getNickname() + " should be excluded",
+                            "excluded".equals(op.getSummary()));
+                }
+            }
+        }
+    }
 
     @Test
     public void testResourceListing() {
-        List<String> controllerPackage = new ArrayList<String>();
-        controllerPackage.add(BASE_CONTROLLER_PACKAGE);
-        List<String> modelPackage = new ArrayList<String>();
-        modelPackage.add(BASE_MODEL_PACKAGE);
-        ApiParser apiParser = new ApiParserImpl(controllerPackage, modelPackage, "http://localhost:8080/api", "/api", "v1", new ArrayList<String>());
+        ApiParser apiParser = createApiParser();
         Map<String, Documentation> documentList = apiParser.createDocuments();
         Documentation resourceList = apiParser.getResourceListing(documentList);
-        assertTrue(resourceList.basePath().equals("http://localhost:8080/api"));
-        assertTrue(resourceList.apiVersion().equals("v1"));
-        assertTrue(resourceList.getApis().size() == 1);
-        DocumentationEndPoint endPoint = resourceList.getApis().get(0);
-        assertEquals(endPoint.getPath(), "/api/doc/api/v1/test");
 
+        assertEquals("http://localhost:8080/api", resourceList.basePath());
+        assertEquals("v1", resourceList.apiVersion());
+        assertEquals(END_POINT_PATHS.size(), resourceList.getApis().size());
+
+        for (DocumentationEndPoint endPoint : resourceList.getApis()) {
+            assertTrue("did u add a new controller without updating the endPoint paths ???", END_POINT_PATHS.contains(endPoint.getPath()));
+        }
+    }
+
+    private ApiParser createApiParser() {
+        return createApiParser(Arrays.asList(BASE_CONTROLLER_PACKAGE), Arrays.asList(BASE_MODEL_PACKAGE));
+    }
+
+    private ApiParser createApiParser(List<String> controllerPackages, List<String> modelPackages) {
+        return new ApiParserImpl(controllerPackages, modelPackages, "http://localhost:8080/api", "/api", "v1", new ArrayList<String>());
     }
 }

--- a/src/test/java/com/knappsack/swagger4springweb/controller/ApiDocumentationControllerTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/controller/ApiDocumentationControllerTest.java
@@ -2,6 +2,7 @@ package com.knappsack.swagger4springweb.controller;
 
 import com.knappsack.swagger4springweb.AbstractTest;
 import com.wordnik.swagger.core.Documentation;
+import com.wordnik.swagger.core.DocumentationEndPoint;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.servlet.HandlerMapping;
@@ -36,10 +37,16 @@ public class ApiDocumentationControllerTest extends AbstractTest {
         apiDocumentationController.setBaseControllerPackage(BASE_CONTROLLER_PACKAGE);
         apiDocumentationController.setBaseModelPackage(BASE_MODEL_PACKAGE);
         apiDocumentationController.setBasePath("http://localhost/swagger4spring-web-example");
+
         Documentation documentation = apiDocumentationController.getResources(servletRequest);
+
         assertNotNull(documentation);
-        assertEquals(documentation.getApiVersion(), "v1");
-        assertTrue(documentation.getApis().size() == 1);
-        assertTrue(documentation.getApis().get(0).getPath().equals("/api/doc/api/v1/test"));
+        assertEquals("v1", documentation.apiVersion());
+        assertEquals(END_POINT_PATHS.size(), documentation.getApis().size());
+        assertEquals("/api/doc/api/v1/test", documentation.getApis().get(0).getPath());
+
+        for (DocumentationEndPoint endPoint : documentation.getApis()) {
+            assertTrue(END_POINT_PATHS.contains(endPoint.getPath()));
+        }
     }
 }

--- a/src/test/java/com/knappsack/swagger4springweb/parser/DocumentationParameterParserTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/parser/DocumentationParameterParserTest.java
@@ -1,6 +1,7 @@
 package com.knappsack.swagger4springweb.parser;
 
 import com.knappsack.swagger4springweb.AbstractTest;
+import com.knappsack.swagger4springweb.testController.TestController;
 import com.wordnik.swagger.core.DocumentationParameter;
 import org.junit.Test;
 
@@ -14,7 +15,7 @@ public class DocumentationParameterParserTest extends AbstractTest {
 
     @Test
     public void documentationParameterTest() throws NoSuchMethodException {
-        Class controllerClass = getControllerClass();
+        Class controllerClass = TestController.class;
         Method method = controllerClass.getMethod("getTestPojoRequestParams", String.class, Boolean.class, Byte.class, Long.class, Integer.class, Float.class, Double.class, Date.class);
         DocumentationParameterParser parameterParser = new DocumentationParameterParser();
         List<DocumentationParameter> documentationParameters = parameterParser.getDocumentationParams(method);

--- a/src/test/java/com/knappsack/swagger4springweb/testController/EmptyTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/EmptyTestController.java
@@ -1,0 +1,12 @@
+package com.knappsack.swagger4springweb.testController;
+
+import com.wordnik.swagger.annotations.Api;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/empty")
+@Api(value = "Test ApiExcludes", listingClass = "EmptyController", basePath = "/api/v1/empty", description = "An empty controller")
+public class EmptyTestController {
+
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/ExcludeClassTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/ExcludeClassTestController.java
@@ -1,0 +1,26 @@
+package com.knappsack.swagger4springweb.testController;
+
+import com.knappsack.swagger4springweb.annotation.ApiExclude;
+import com.knappsack.swagger4springweb.testModels.TestPojo;
+import com.wordnik.swagger.annotations.Api;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+@RequestMapping("/api/v1/exclude3")
+@ApiExclude
+@Api(value = "Test ApiExcludes", listingClass = "ExcludeClassTestController", basePath = "/api/v1/exclude3", description = "controller to exclude")
+public class ExcludeClassTestController {
+
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json")
+    public
+    @ResponseBody
+    List<TestPojo> apiOperation1ToInclude() {
+        return new ArrayList<TestPojo>();
+    }
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/ExcludeSingleOpTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/ExcludeSingleOpTestController.java
@@ -1,0 +1,29 @@
+package com.knappsack.swagger4springweb.testController;
+
+import com.knappsack.swagger4springweb.AbstractTest;
+import com.knappsack.swagger4springweb.annotation.ApiExclude;
+import com.knappsack.swagger4springweb.testModels.TestPojo;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+@RequestMapping("/api/v1/exclude2")
+@Api(value = "Test ApiExcludes", listingClass = "ExcludeSingleOpTestController", basePath = "/api/v1/exclude2", description = "Some operations to exclude")
+public class ExcludeSingleOpTestController {
+
+    @ApiExclude
+    @ApiOperation(value = AbstractTest.EXCLUDE_LABEL)
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json")
+    public
+    @ResponseBody
+    List<TestPojo> apiOperation1ToInclude() {
+        return new ArrayList<TestPojo>();
+    }
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/PartialExcludeTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/PartialExcludeTestController.java
@@ -1,0 +1,52 @@
+package com.knappsack.swagger4springweb.testController;
+
+import com.knappsack.swagger4springweb.AbstractTest;
+import com.knappsack.swagger4springweb.annotation.ApiExclude;
+import com.knappsack.swagger4springweb.testModels.TestPojo;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+@RequestMapping("/api/v1/partialExclude")
+@Api(value = "Test ApiExcludes", listingClass = "PartialExcludeTestController", basePath = "/api/v1/partialExclude", description = "Some operations to exclude")
+public class PartialExcludeTestController {
+
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json")
+    public
+    @ResponseBody
+    List<TestPojo> apiOperation1ToInclude() {
+        return new ArrayList<TestPojo>();
+    }
+
+    @ApiOperation(value = AbstractTest.EXCLUDE_LABEL)
+    @RequestMapping(method = RequestMethod.POST, produces = "application/json")
+    @ApiExclude
+    public
+    @ResponseBody
+    List<TestPojo> apiOperation2ToExclude() {
+        return new ArrayList<TestPojo>();
+    }
+
+    @RequestMapping(value = "/resource1", method = RequestMethod.GET, produces = "application/json")
+    public
+    @ResponseBody
+    TestPojo apiOperation3ToInclude() {
+        return new TestPojo();
+    }
+
+    @ApiOperation(value = AbstractTest.EXCLUDE_LABEL)
+    @RequestMapping(value = "/resource2", method = RequestMethod.GET, produces = "application/json")
+    @ApiExclude
+    public
+    @ResponseBody
+    TestPojo apiOperation4ToExclude() {
+        return new TestPojo();
+    }
+}


### PR DESCRIPTION
@ApiExclude 
add an annotation which allows one to specify which controller classes or methods he wishes not to document in the swagger generated API
