### PR TITLE
Adding slash to beginning of resourcePath when building ApiListing if no...

### DIFF
--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -54,9 +54,6 @@ public class ApiParserImpl implements ApiParser {
         for (String key : apiListingMap.keySet()) {
             ApiListing apiListing = apiListingMap.get(key);
             String docPath = "/doc"; //servletPath + "/doc"; //"/api/doc";
-            if (!key.startsWith("/")) {
-                docPath = docPath + "/";
-            }
             ApiListingReference apiListingReference = new ApiListingReference(docPath + key, apiListing.description(),
                     count);
 
@@ -126,6 +123,9 @@ public class ApiParserImpl implements ApiParser {
             } else {
                 resourcePath = controllerClass.getName();
             }
+        }
+        if (!resourcePath.startsWith("/")) {
+            resourcePath = "/" + resourcePath;
         }
 
         SpringApiReader reader = new SpringApiReader();

--- a/src/test/java/com/knappsack/swagger4springweb/AbstractTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/AbstractTest.java
@@ -9,6 +9,6 @@ public abstract class AbstractTest {
 
     public static final String BASE_CONTROLLER_PACKAGE = "com.knappsack.swagger4springweb.testController";
     public static final String EXCLUDE_LABEL = "exclude";
-    public static final List<String> END_POINT_PATHS = Arrays.asList("/doc/api/v1/partialExclude", "/doc/api/v1/test", "/doc/api/v1/exclude2");
+    public static final List<String> END_POINT_PATHS = Arrays.asList("/doc/api/v1/partialExclude", "/doc/api/v1/test", "/doc/api/v1/exclude2", "/doc/com.knappsack.swagger4springweb.testController.NoClassLevelMappingController");
     public static final ApiInfo API_INFO = new ApiInfo("swagger4spring-web example app", "This is a basic web app for demonstrating swagger4spring-web", "http://localhost:8080/terms", "http://localhost:8080/contact", "MIT", "http://opensource.org/licenses/MIT");
 }

--- a/src/test/java/com/knappsack/swagger4springweb/ApiParserTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiParserTest.java
@@ -8,6 +8,7 @@ import com.wordnik.swagger.core.SwaggerSpec;
 import com.wordnik.swagger.core.util.JsonSerializer;
 import com.wordnik.swagger.model.ApiDescription;
 import com.wordnik.swagger.model.ApiListing;
+import com.wordnik.swagger.model.ApiListingReference;
 import com.wordnik.swagger.model.Operation;
 import com.wordnik.swagger.model.ResourceListing;
 import org.junit.Test;
@@ -71,6 +72,16 @@ public class ApiParserTest extends AbstractTest {
 //        for (DocumentationEndPoint endPoint : resourceList.getApis()) {
 //            assertTrue("did u add a new controller without updating the endPoint paths ???", END_POINT_PATHS.contains(endPoint.getPath()));
 //        }
+    }
+
+    @Test
+    public void testNoClassRequestMapping() {
+        ApiParser apiParser = createApiParser();
+        Map<String, ApiListing> documentList = apiParser.createApiListings();
+        ResourceListing resourceList = apiParser.getResourceListing(documentList);
+        for (ApiListingReference api: ScalaToJavaUtil.toJavaList(resourceList.apis())) {
+            assertNotNull("could not get api listing for path: " + api.path(), documentList.get(api.path().substring(4))); // each api should be accessible using the ApiListingReference minus /doc
+        }
     }
 
     private ApiParser createApiParser() {

--- a/src/test/java/com/knappsack/swagger4springweb/testController/NoClassLevelMappingController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/NoClassLevelMappingController.java
@@ -1,0 +1,21 @@
+package com.knappsack.swagger4springweb.testController;
+
+import com.knappsack.swagger4springweb.testModels.MockPojo;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class NoClassLevelMappingController {
+
+	@RequestMapping(value = "/api/v1/noClassLevelMapping", method = RequestMethod.GET, produces = "application/json")
+	public
+	@ResponseBody
+	List<MockPojo> noRoot() {
+		return new ArrayList<MockPojo>();
+	}
+}


### PR DESCRIPTION
...t present. When building ResourceListing api's had slashes added to their ApiListingReference, when this reference was accessed the slash remained. The map containing path to ApiListing objects did not have the slash so none was found.
