### PR TITLE
Filtering mechanism

### DIFF
--- a/src/main/java/com/knappsack/swagger4springweb/filter/AnnotationFilter.java
+++ b/src/main/java/com/knappsack/swagger4springweb/filter/AnnotationFilter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2013 AlertMe.com Ltd
+ */
+
+package com.knappsack.swagger4springweb.filter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+
+public abstract class AnnotationFilter<T extends Annotation> implements Filter {
+
+    protected final Class<T> annotation;
+
+    protected AnnotationFilter(final Class<T> annotation) {
+        this.annotation = annotation;
+    }
+
+    @Override
+    public final boolean isApplicable(final Method method) {
+        return isApplicable((AnnotatedElement) method) || isApplicable(method.getDeclaringClass());
+    }
+
+    @Override
+    public final boolean ignore(final Method method) {
+        final T annotation = method.getAnnotation(this.annotation);
+        return ignore(annotation != null ? annotation : method.getDeclaringClass().getAnnotation(this.annotation));
+    }
+
+    public abstract boolean ignore(final T annotation);
+
+    protected boolean isApplicable(final AnnotatedElement element) {
+        return element.isAnnotationPresent(annotation);
+    }
+}

--- a/src/main/java/com/knappsack/swagger4springweb/filter/ApiExcludeFilter.java
+++ b/src/main/java/com/knappsack/swagger4springweb/filter/ApiExcludeFilter.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2013 AlertMe.com Ltd
+ */
+
+package com.knappsack.swagger4springweb.filter;
+
+import com.knappsack.swagger4springweb.annotation.ApiExclude;
+
+public class ApiExcludeFilter extends AnnotationFilter<ApiExclude> {
+
+    public ApiExcludeFilter() {
+        super(ApiExclude.class);
+    }
+
+    @Override
+    public boolean ignore(final ApiExclude annotation) {
+        return true;
+    }
+}

--- a/src/main/java/com/knappsack/swagger4springweb/filter/Filter.java
+++ b/src/main/java/com/knappsack/swagger4springweb/filter/Filter.java
@@ -1,0 +1,11 @@
+package com.knappsack.swagger4springweb.filter;
+
+import java.lang.reflect.Method;
+
+public interface Filter {
+
+    boolean isApplicable(Method method);
+
+    boolean ignore(Method method);
+
+}

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiOperationParser.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiOperationParser.java
@@ -59,7 +59,7 @@ public class ApiOperationParser {
                         .setResponseContainer(((Class<?>) parameterizedType.getRawType()));
             } else {
                 // TODO what to do here?
-                // not supporting generic containing other generic
+                // not supporting generic with several values
             }
         }
 

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -1,7 +1,8 @@
 package com.knappsack.swagger4springweb.parser;
 
-import com.knappsack.swagger4springweb.annotation.ApiExclude;
 import com.knappsack.swagger4springweb.controller.ApiDocumentationController;
+import com.knappsack.swagger4springweb.filter.ApiExcludeFilter;
+import com.knappsack.swagger4springweb.filter.Filter;
 import com.knappsack.swagger4springweb.util.AnnotationUtils;
 import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
 import com.knappsack.swagger4springweb.util.ScalaToJavaUtil;
@@ -22,22 +23,27 @@ public class ApiParserImpl implements ApiParser {
 
     private static final String swaggerVersion = com.wordnik.swagger.core.SwaggerSpec.version();
 
-    private List<String> controllerPackages = new ArrayList<String>();
+    private final Map<String, ApiListing> apiListingMap = new HashMap<String, ApiListing>();
+
+    private final List<String> controllerPackages;
+    private final List<String> ignorableAnnotations;
+    private final List<Filter> filters;
+
     private String basePath = "";
     private String apiVersion = "v1";
-    private List<String> ignorableAnnotations;
     private boolean ignoreUnusedPathVariables;
     private SwaggerConfig swaggerConfig;
 
-    private final Map<String, ApiListing> apiListingMap = new HashMap<String, ApiListing>();
-
     public ApiParserImpl(ApiInfo apiInfo, List<String> baseControllerPackage, String basePath, String servletPath,
-            String apiVersion, List<String> ignorableAnnotations, boolean ignoreUnusedPathVariables) {
+            String apiVersion, List<String> ignorableAnnotations, boolean ignoreUnusedPathVariables,
+            List<Filter> filters) {
+
         this.controllerPackages = baseControllerPackage;
         this.ignorableAnnotations = ignorableAnnotations;
         this.ignoreUnusedPathVariables = ignoreUnusedPathVariables;
         this.basePath = basePath;
         this.apiVersion = apiVersion;
+
         swaggerConfig = new SwaggerConfig();
         if (apiInfo != null) {
             swaggerConfig.setApiInfo(apiInfo);
@@ -46,6 +52,12 @@ public class ApiParserImpl implements ApiParser {
         swaggerConfig.setApiVersion(apiVersion);
         swaggerConfig.setBasePath(basePath);
         swaggerConfig.setSwaggerVersion(swaggerVersion);
+
+        this.filters = new ArrayList<Filter>();
+        this.filters.add(new ApiExcludeFilter()); // @ApiExclude filter
+        if (filters != null) {
+            this.filters.addAll(filters);
+        }
     }
 
     public ResourceListing getResourceListing(Map<String, ApiListing> apiListingMap) {
@@ -82,10 +94,6 @@ public class ApiParserImpl implements ApiParser {
         //Loop over end points (controllers)
         for (Class<?> controllerClass : controllerClasses) {
             if (ApiDocumentationController.class.isAssignableFrom(controllerClass)) {
-                continue;
-            }
-
-            if (controllerClass.isAnnotationPresent(ApiExclude.class)) {
                 continue;
             }
 
@@ -150,56 +158,48 @@ public class ApiParserImpl implements ApiParser {
     }
 
     private ApiListing processMethods(Collection<Method> methods, ApiListing apiListing, String description) {
-        Map<String, ApiDescription> endPointMap = new HashMap<String, ApiDescription>();
 
-        populateApiDescriptionMapForApiListing(apiListing, endPointMap);
-
-        for (Method method : methods) {
-            if (method.isAnnotationPresent(ApiExclude.class)) {
-                continue;
-            }
-
-            String requestMappingValue = AnnotationUtils.getMethodRequestMappingValue(method);
-            ApiDescriptionParser documentationEndPointParser = new ApiDescriptionParser();
-            ApiDescription apiDescription = documentationEndPointParser
-                    .parseApiDescription(method, description, apiListing.resourcePath());
-            if (!endPointMap.containsKey(requestMappingValue)) {
-                endPointMap.put(requestMappingValue, apiDescription);
-            }
-        }
-
+        Map<String, ApiDescription> endpoints = new HashMap<String, ApiDescription>();
         Map<String, Model> models = new HashMap<String, Model>();
+        Map<String, List<Operation>> operations = new HashMap<String, List<Operation>>();
+        List<ApiDescription> descriptions = new ArrayList<ApiDescription>();
 
-        Map<String, List<Operation>> operationMap = new HashMap<String, List<Operation>>();
+        populateApiDescriptionMapForApiListing(apiListing, endpoints);
+
+        ApiModelParser apiModelParser = new ApiModelParser(models);
+
         for (Method method : methods) {
-            if (method.isAnnotationPresent(ApiExclude.class)) {
+            if (ignore(method)) {
                 continue;
             }
 
             String value = AnnotationUtils.getMethodRequestMappingValue(method);
-            List<Operation> operations = operationMap.get(value);
-            if (operations == null) {
-                operations = new ArrayList<Operation>();
-                operationMap.put(value, operations);
+            ApiDescriptionParser documentationEndPointParser = new ApiDescriptionParser();
+            ApiDescription apiDescription = documentationEndPointParser
+                    .parseApiDescription(method, description, apiListing.resourcePath());
+            if (!endpoints.containsKey(value)) {
+                endpoints.put(value, apiDescription);
+            }
+
+            List<Operation> ops = operations.get(value);
+            if (ops == null) {
+                ops = new ArrayList<Operation>();
+                operations.put(value, ops);
             }
 
             ApiOperationParser apiOperationParser = new ApiOperationParser(apiListing.resourcePath(),
                     ignorableAnnotations, ignoreUnusedPathVariables, models);
             Operation operation = apiOperationParser.parseDocumentationOperation(method);
-            operations.add(operation);
-        }
+            ops.add(operation);
 
-        List<ApiDescription> newApiDescriptions = new ArrayList<ApiDescription>();
-        for (String key : endPointMap.keySet()) {
-            ApiDescription apiDescription = endPointMap.get(key);
-            ApiDescription newApiDescription = new ApiDescription(apiDescription.path(), apiDescription.description(),
-                    JavaToScalaUtil.toScalaList(operationMap.get(key)));
-            newApiDescriptions.add(newApiDescription);
-        }
-
-        ApiModelParser apiModelParser = new ApiModelParser(models);
-        for (Method method : methods) {
             apiModelParser.parseResponseBodyModels(method);
+        }
+
+        for (String key : endpoints.keySet()) {
+            ApiDescription apiDescription = endpoints.get(key);
+            ApiDescription newApiDescription = new ApiDescription(apiDescription.path(), apiDescription.description(),
+                    JavaToScalaUtil.toScalaList(operations.get(key)));
+            descriptions.add(newApiDescription);
         }
 
         Option<scala.collection.immutable.Map<String, Model>> modelOptions = Option
@@ -207,7 +207,7 @@ public class ApiParserImpl implements ApiParser {
 
         return new ApiListing(apiListing.apiVersion(), apiListing.swaggerVersion(), apiListing.basePath(),
                 apiListing.resourcePath(), apiListing.produces(), apiListing.consumes(), apiListing.protocols(),
-                apiListing.authorizations(), JavaToScalaUtil.toScalaList(newApiDescriptions), modelOptions,
+                apiListing.authorizations(), JavaToScalaUtil.toScalaList(descriptions), modelOptions,
                 apiListing.description(), apiListing.position());
     }
 
@@ -221,4 +221,14 @@ public class ApiParserImpl implements ApiParser {
             }
         }
     }
+
+    private boolean ignore(Method method) {
+        for (Filter filter : filters) {
+            if (filter.isApplicable(method) && filter.ignore(method)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/test/java/com/knappsack/swagger4springweb/ApiParserTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiParserTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 public class ApiParserTest extends AbstractTest {
+
     @Test
     public void testParseControllerDocumentation() {
         Map<String, ApiListing> documentList = createApiParser().createApiListings();
@@ -31,7 +32,6 @@ public class ApiParserTest extends AbstractTest {
                 String documentationAsJSON = mapper.writeValueAsString(documentation);
                 System.out.println(documentationAsJSON);
                 ApiListing documentationDeserialized = JsonSerializer.asApiListing(documentationAsJSON);
-//                ApiListing documentationDeserialized = mapper.readValue(documentationAsJSON, ApiListing.class);
                 assertNotNull(documentationDeserialized);
                 assertTrue(documentationDeserialized.swaggerVersion().equals(SwaggerSpec.version()));
                 assertTrue(documentationDeserialized.apiVersion().equals("v1"));
@@ -44,15 +44,17 @@ public class ApiParserTest extends AbstractTest {
 
     @Test
     public void testOperationApiExclude() {
-        ApiParser apiParser = createApiParser();
+        ApiParser apiParser = createApiParser(Arrays.asList(BASE_CONTROLLER_PACKAGE + ".exclude"));
         Map<String, ApiListing> documents = apiParser.createApiListings();
+
+        assertEquals(2, documents.size()); // ExcludeClassTestController excluded completely
 
         // validate that we don't expose any excluded operations in the documents
         for (ApiListing documentation : documents.values()) {
             for (ApiDescription api : ScalaToJavaUtil.toJavaList(documentation.apis())) {
                 for (Operation op : ScalaToJavaUtil.toJavaList(api.operations())) {
-                    assertFalse("The operation " + op.nickname() + " should be excluded",
-                            "excluded".equals(op.summary()));
+                    assertTrue("The operation " + op.nickname() + " should be excluded",
+                            "exclude".equals(op.summary()));
                 }
             }
         }
@@ -78,6 +80,7 @@ public class ApiParserTest extends AbstractTest {
     }
 
     private ApiParser createApiParser(List<String> controllerPackages) {
-        return new ApiParserImpl(API_INFO, controllerPackages, "http://localhost:8080/api", "/api", "v1", new ArrayList<String>(), true);
+        return new ApiParserImpl(API_INFO, controllerPackages, "http://localhost:8080/api", "/api", "v1",
+                new ArrayList<String>(), true, null);
     }
 }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/exclude/ExcludeClassTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/exclude/ExcludeClassTestController.java
@@ -1,10 +1,8 @@
-package com.knappsack.swagger4springweb.testController;
+package com.knappsack.swagger4springweb.testController.exclude;
 
-import com.knappsack.swagger4springweb.AbstractTest;
 import com.knappsack.swagger4springweb.annotation.ApiExclude;
 import com.knappsack.swagger4springweb.testModels.MockPojo;
 import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -14,16 +12,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Controller
-@RequestMapping("/api/v1/exclude2")
-@Api(value = "Test ApiExcludes", basePath = "/api/v1/exclude2", description = "Some operations to exclude")
-public class ExcludeSingleOpTestController {
+@RequestMapping("/api/v1/exclude3")
+@ApiExclude
+@Api(value = "Test ApiExcludes", basePath = "/api/v1/exclude3", description = "controller to exclude")
+public class ExcludeClassTestController {
 
-    @ApiExclude
-    @ApiOperation(value = AbstractTest.EXCLUDE_LABEL)
     @RequestMapping(method = RequestMethod.GET, produces = "application/json")
     public
     @ResponseBody
-    List<MockPojo> apiOperation1ToInclude() {
+    List<MockPojo> apiOperation1ToExclude() {
         return new ArrayList<MockPojo>();
     }
 }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/exclude/ExcludeSingleOpTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/exclude/ExcludeSingleOpTestController.java
@@ -1,8 +1,10 @@
-package com.knappsack.swagger4springweb.testController;
+package com.knappsack.swagger4springweb.testController.exclude;
 
+import com.knappsack.swagger4springweb.AbstractTest;
 import com.knappsack.swagger4springweb.annotation.ApiExclude;
 import com.knappsack.swagger4springweb.testModels.MockPojo;
 import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -12,15 +14,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Controller
-@RequestMapping("/api/v1/exclude3")
-@ApiExclude
-@Api(value = "Test ApiExcludes", basePath = "/api/v1/exclude3", description = "controller to exclude")
-public class ExcludeClassTestController {
+@RequestMapping("/api/v1/exclude2")
+@Api(value = "Test ApiExcludes", basePath = "/api/v1/exclude2", description = "The only operation to exclude")
+public class ExcludeSingleOpTestController {
 
+    @ApiExclude
+    @ApiOperation(value = AbstractTest.EXCLUDE_LABEL)
     @RequestMapping(method = RequestMethod.GET, produces = "application/json")
     public
     @ResponseBody
-    List<MockPojo> apiOperation1ToInclude() {
+    List<MockPojo> apiOperation1ToExclude() {
         return new ArrayList<MockPojo>();
     }
 }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/exclude/PartialExcludeTestController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/exclude/PartialExcludeTestController.java
@@ -1,4 +1,4 @@
-package com.knappsack.swagger4springweb.testController;
+package com.knappsack.swagger4springweb.testController.exclude;
 
 import com.knappsack.swagger4springweb.AbstractTest;
 import com.knappsack.swagger4springweb.annotation.ApiExclude;


### PR DESCRIPTION
There is now an ability to set excluding filters (in runtime or when initializing) so that some of the results (controllers or methods) would be ignored (e.g. filtered by api version or device).
Excluding with @ApiExclude uses this mechanism from now and could be used as an example.

Usage:
&lt;bean class="com.knappsack.swagger4springweb.controller.ApiDocumentationController"&gt;  
&nbsp;&nbsp;&lt;property name="filters"&gt;
&nbsp;&nbsp;&nbsp;&nbsp;&lt;list&gt;
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ref bean="filter1"/&gt;
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ref bean="filter2"/&gt;
&nbsp;&nbsp;&nbsp;&nbsp;&lt;/list&gt;
&nbsp;&nbsp;&lt;/property&gt;
&lt;/bean&gt;

Or they could be added "on the go" using setFilters(..)
