### PR TITLE
Fixes GH-69. Any api with `/doc` was failing.

### DIFF
--- a/src/main/java/com/knappsack/swagger4springweb/controller/ApiDocumentationController.java
+++ b/src/main/java/com/knappsack/swagger4springweb/controller/ApiDocumentationController.java
@@ -60,7 +60,7 @@ public class ApiDocumentationController {
                 HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
         //trim the operation request mapping from the desired value
         handlerMappingPath = handlerMappingPath
-                .substring(handlerMappingPath.lastIndexOf("/doc") + 4, handlerMappingPath.length());
+                .substring(handlerMappingPath.indexOf("/doc/") + 4, handlerMappingPath.length());
 
         Map<String, ApiListing> docs = getDocs(request);
         if (docs == null) {


### PR DESCRIPTION
The problem is that the documentation controller was keying off the last
index of `/doc` which causes issues if you have any api's that have that
path.

So, the fix is to look for the first index of `/doc/`.

Signed-off-by: Nick Campbell nicholas.j.campbell@gmail.com
