### PR TITLE
Categories

### DIFF
--- a/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
+++ b/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
@@ -1,0 +1,18 @@
+package com.knappsack.swagger4springweb.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation which indicates if this Api should be added to a category
+ *
+ * This annotation is applicable to the controller class
+ */
+@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface ApiCategory {
+  java.lang.String value();
+
+}

--- a/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
+++ b/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
@@ -14,6 +14,5 @@ import java.lang.annotation.Target;
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface ApiCategory {
   java.lang.String value();
-
-  // TODO Description
+  java.lang.String description() default "";
 }

--- a/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
+++ b/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
@@ -7,12 +7,13 @@ import java.lang.annotation.Target;
 
 /**
  * An annotation which indicates if this Api should be added to a category
- *
+ * <p/>
  * This annotation is applicable to the controller class
  */
-@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Target(ElementType.ANNOTATION_TYPE)
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface ApiCategory {
   java.lang.String value();
+
   java.lang.String description() default "";
 }

--- a/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
+++ b/src/main/java/com/knappsack/swagger4springweb/annotation/ApiCategory.java
@@ -15,4 +15,5 @@ import java.lang.annotation.Target;
 public @interface ApiCategory {
   java.lang.String value();
 
+  // TODO Description
 }

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiOperationParser.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiOperationParser.java
@@ -1,27 +1,35 @@
 package com.knappsack.swagger4springweb.parser;
 
-import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
-import com.wordnik.swagger.annotations.*;
-import com.wordnik.swagger.converter.ModelConverters;
-import com.wordnik.swagger.model.*;
-import com.wordnik.swagger.model.Authorization;
-import com.wordnik.swagger.model.AuthorizationScope;
-import org.apache.commons.lang.ArrayUtils;
-import org.springframework.http.HttpMethod;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import scala.Option;
+import static java.lang.String.format;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static java.lang.String.format;
+import org.apache.commons.lang.ArrayUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+import com.wordnik.swagger.converter.ModelConverters;
+import com.wordnik.swagger.model.Authorization;
+import com.wordnik.swagger.model.AuthorizationScope;
+import com.wordnik.swagger.model.Model;
+import com.wordnik.swagger.model.Operation;
+import com.wordnik.swagger.model.Parameter;
+import com.wordnik.swagger.model.ResponseMessage;
+
+import scala.Option;
 
 public class ApiOperationParser {
 
@@ -51,6 +59,8 @@ public class ApiOperationParser {
                 final Type type = parameterizedType.getActualTypeArguments()[0];
                 if (type instanceof ParameterizedType) {
                     documentationOperation.setResponseClass((Class<?>) ((ParameterizedType) type).getRawType());
+                } else if (type instanceof WildcardType) {
+                    documentationOperation.setResponseClass(Object.class);
                 } else {
                     documentationOperation.setResponseClass((Class<?>) type);
                 }

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -25,8 +25,8 @@ import com.knappsack.swagger4springweb.controller.ApiDocumentationController;
 import com.knappsack.swagger4springweb.filter.ApiExcludeFilter;
 import com.knappsack.swagger4springweb.filter.Filter;
 import com.knappsack.swagger4springweb.util.AnnotationUtils;
-import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
 import com.knappsack.swagger4springweb.util.ApiListingUtil;
+import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
 import com.knappsack.swagger4springweb.util.ScalaToJavaUtil;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.config.SwaggerConfig;
@@ -87,7 +87,7 @@ public class ApiParserImpl implements ApiParser {
         List<ApiListingReference> apiListingReferences = new ArrayList<ApiListingReference>();
         for (String key : apiListingMap.keySet()) {
             ApiListing apiListing = apiListingMap.get(key);
-            String docPath = "/doc"; //servletPath + "/doc"; //"/api/doc";
+          String docPath = "/doc"; //servletPath + "/doc"; //"/api/doc";
             ApiListingReference apiListingReference = new ApiListingReference(docPath + key, apiListing.description(),
                     apiListing.position());
 
@@ -115,7 +115,7 @@ public class ApiParserImpl implements ApiParser {
                 swaggerConfig.info());
     }
 
-    public Map<String, ApiListing> createApiListings() {
+  public Map<String, ApiListing> createApiListings() {
         Set<Class<?>> controllerClasses = new HashSet<Class<?>>();
         for (String controllerPackage : controllerPackages) {
             Reflections reflections = new Reflections(controllerPackage);
@@ -152,12 +152,13 @@ public class ApiParserImpl implements ApiParser {
             }
             ApiCategory apiCategory = controllerClass.getAnnotation(ApiCategory.class);
             if (apiCategory != null && apiCategory.value() != null) {
-              ApiListing existingApiListing = apiListingMap.get(apiCategory.value());
+              String key = prependSlashIfMissing(apiCategory.value());
+              ApiListing existingApiListing = apiListingMap.get(key);
               if (existingApiListing != null) {
                 apiListing = ApiListingUtil.combine(existingApiListing, apiListing);
               }
 
-              apiListingMap.put(apiCategory.value(), apiListing);
+              apiListingMap.put(key, apiListing);
               continue;
             }
 
@@ -186,11 +187,9 @@ public class ApiParserImpl implements ApiParser {
                 resourcePath = controllerClass.getName();
             }
         }
-        if (!resourcePath.startsWith("/")) {
-            resourcePath = "/" + resourcePath;
-        }
+      resourcePath = prependSlashIfMissing(resourcePath);
 
-        String docRoot = resourcePath;
+      String docRoot = resourcePath;
         if(docRoot.contains(controllerClass.getName())) {
             docRoot = docRoot.replace(controllerClass.getName(), "");
         }
@@ -294,6 +293,13 @@ public class ApiParserImpl implements ApiParser {
             }
         }
         return false;
+    }
+
+    private String prependSlashIfMissing(String key) {
+      if (!key.startsWith("/")) {
+        key = "/" + key;
+      }
+      return key;
     }
 
 }

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -2,6 +2,7 @@ package com.knappsack.swagger4springweb.parser;
 
 import static org.reflections.ReflectionUtils.withAnnotation;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -151,7 +152,7 @@ public class ApiParserImpl implements ApiParser {
             if (apiListing.apis() == null) {
                 apiListing = processMethods(requestMappingMethods, controllerClass, apiListing, description);
             }
-            ApiCategory apiCategory = controllerClass.getAnnotation(ApiCategory.class);
+          ApiCategory apiCategory = getApiCategoryAnnotation(controllerClass);
             if (apiCategory != null && apiCategory.value() != null) {
               String key = prependSlashIfMissing(apiCategory.value());
               ApiListing existingApiListing = apiListingMap.get(key);
@@ -171,6 +172,17 @@ public class ApiParserImpl implements ApiParser {
 
         return apiListingMap;
     }
+
+  private ApiCategory getApiCategoryAnnotation(Class<?> controllerClass) {
+    Annotation[] annotations = controllerClass.getAnnotations();
+    for (Annotation annotation : annotations) {
+      ApiCategory value = org.springframework.core.annotation.AnnotationUtils.getAnnotation(annotation, ApiCategory.class);
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
+  }
 
   private void addApiListingToMap(ApiListing apiListing, String key) {
     apiListingMap.put(key, ApiListingUtil.sortApisByPath(apiListing));

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -1,28 +1,44 @@
 package com.knappsack.swagger4springweb.parser;
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
-import com.knappsack.swagger4springweb.controller.ApiDocumentationController;
-import com.knappsack.swagger4springweb.filter.ApiExcludeFilter;
-import com.knappsack.swagger4springweb.filter.Filter;
-import com.knappsack.swagger4springweb.util.AnnotationUtils;
-import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
-import com.knappsack.swagger4springweb.util.ScalaToJavaUtil;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.config.SwaggerConfig;
-import com.wordnik.swagger.model.*;
+import static org.reflections.ReflectionUtils.withAnnotation;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.knappsack.swagger4springweb.controller.ApiDocumentationController;
+import com.knappsack.swagger4springweb.filter.ApiExcludeFilter;
+import com.knappsack.swagger4springweb.filter.Filter;
+import com.knappsack.swagger4springweb.util.AnnotationUtils;
+import com.knappsack.swagger4springweb.util.JavaToScalaUtil;
+import com.knappsack.swagger4springweb.util.ApiListingUtil;
+import com.knappsack.swagger4springweb.util.ScalaToJavaUtil;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.config.SwaggerConfig;
+import com.wordnik.swagger.model.ApiDescription;
+import com.wordnik.swagger.model.ApiInfo;
+import com.wordnik.swagger.model.ApiListing;
+import com.wordnik.swagger.model.ApiListingReference;
+import com.wordnik.swagger.model.Model;
+import com.wordnik.swagger.model.Operation;
+import com.wordnik.swagger.model.ResourceListing;
+
 import scala.Option;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.*;
-
-import static org.reflections.ReflectionUtils.withAnnotation;
 
 public class ApiParserImpl implements ApiParser {
 
@@ -136,6 +152,11 @@ public class ApiParserImpl implements ApiParser {
             }
             ApiCategory apiCategory = controllerClass.getAnnotation(ApiCategory.class);
             if (apiCategory != null && apiCategory.value() != null) {
+              ApiListing existingApiListing = apiListingMap.get(apiCategory.value());
+              if (existingApiListing != null) {
+                apiListing = ApiListingUtil.combine(existingApiListing, apiListing);
+              }
+
               apiListingMap.put(apiCategory.value(), apiListing);
               continue;
             }

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
@@ -46,7 +47,7 @@ public class ApiParserImpl implements ApiParser {
 
     private static final String swaggerVersion = com.wordnik.swagger.core.SwaggerSpec.version();
 
-    private final Map<String, ApiListing> apiListingMap = new HashMap<String, ApiListing>();
+    private final Map<String, ApiListing> apiListingMap = new TreeMap<>();
 
     private final List<String> controllerPackages;
     private final List<String> ignorableAnnotations;
@@ -158,18 +159,23 @@ public class ApiParserImpl implements ApiParser {
                 apiListing = ApiListingUtil.combine(existingApiListing, apiListing);
               }
 
-              apiListingMap.put(key, apiListing);
+              addApiListingToMap(apiListing, key);
               continue;
             }
 
             // controllers without any operations are excluded from the apiListingMap list
             if (apiListing.apis() != null && !apiListing.apis().isEmpty()) {
-                apiListingMap.put(apiListing.resourcePath(), apiListing);
+              addApiListingToMap(apiListing, apiListing.resourcePath());
             }
         }
 
         return apiListingMap;
     }
+
+  private void addApiListingToMap(ApiListing apiListing, String key) {
+    apiListingMap.put(key, ApiListingUtil.sortApisByPath(apiListing));
+  }
+
 
     private ApiListing processControllerApi(Class<?> controllerClass) {
         String resourcePath = "";

--- a/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
+++ b/src/main/java/com/knappsack/swagger4springweb/parser/ApiParserImpl.java
@@ -1,5 +1,6 @@
 package com.knappsack.swagger4springweb.parser;
 
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
 import com.knappsack.swagger4springweb.controller.ApiDocumentationController;
 import com.knappsack.swagger4springweb.filter.ApiExcludeFilter;
 import com.knappsack.swagger4springweb.filter.Filter;
@@ -132,6 +133,11 @@ public class ApiParserImpl implements ApiParser {
 
             if (apiListing.apis() == null) {
                 apiListing = processMethods(requestMappingMethods, controllerClass, apiListing, description);
+            }
+            ApiCategory apiCategory = controllerClass.getAnnotation(ApiCategory.class);
+            if (apiCategory != null && apiCategory.value() != null) {
+              apiListingMap.put(apiCategory.value(), apiListing);
+              continue;
             }
 
             // controllers without any operations are excluded from the apiListingMap list

--- a/src/main/java/com/knappsack/swagger4springweb/util/AnnotationUtils.java
+++ b/src/main/java/com/knappsack/swagger4springweb/util/AnnotationUtils.java
@@ -1,17 +1,18 @@
 package com.knappsack.swagger4springweb.util;
 
-import com.google.common.collect.Lists;
-import com.knappsack.swagger4springweb.model.AnnotatedParameter;
-import com.thoughtworks.paranamer.BytecodeReadingParanamer;
-import com.thoughtworks.paranamer.Paranamer;
-import com.wordnik.swagger.annotations.ApiParam;
-import org.springframework.web.bind.annotation.RequestMapping;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.google.common.collect.Lists;
+import com.knappsack.swagger4springweb.model.AnnotatedParameter;
+import com.thoughtworks.paranamer.BytecodeReadingParanamer;
+import com.thoughtworks.paranamer.Paranamer;
+import com.wordnik.swagger.annotations.ApiParam;
 
 public class AnnotationUtils {
 
@@ -84,4 +85,23 @@ public class AnnotationUtils {
         }
         return annotatedParameters;
     }
+
+
+  public static <T extends Annotation> T getAnnotationAnnotation(Class<T> annotationClass, Class<?> controllerClass) {
+    Annotation[] annotations = controllerClass.getAnnotations();
+    for (Annotation annotation : annotations) {
+      T value = getAnnotation(annotation, annotationClass);
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private static <T extends Annotation> T getAnnotation(Annotation ann, Class<T> annotationType) {
+    if (annotationType.isInstance(ann)) {
+      return (T) ann;
+    }
+    return ann.annotationType().getAnnotation(annotationType);
+  }
 }

--- a/src/main/scala/com/knappsack/swagger4springweb/util/ApiListingUtil.scala
+++ b/src/main/scala/com/knappsack/swagger4springweb/util/ApiListingUtil.scala
@@ -7,4 +7,5 @@ import com.wordnik.swagger.model.ApiListing
  */
 object ApiListingUtil {
   def combine(main: ApiListing, additional : ApiListing) : ApiListing = main.copy(apis = main.apis ++ additional.apis)
+  def sortApisByPath(obj: ApiListing) : ApiListing = obj.copy(apis = obj.apis.sortBy(api => api.path))
 }

--- a/src/main/scala/com/knappsack/swagger4springweb/util/ApiListingUtil.scala
+++ b/src/main/scala/com/knappsack/swagger4springweb/util/ApiListingUtil.scala
@@ -1,0 +1,10 @@
+package com.knappsack.swagger4springweb.util
+
+import com.wordnik.swagger.model.ApiListing
+
+/**
+ * @author Allar Tammik
+ */
+object ApiListingUtil {
+  def combine(main: ApiListing, additional : ApiListing) : ApiListing = main.copy(apis = main.apis ++ additional.apis)
+}

--- a/src/main/scala/com/knappsack/swagger4springweb/util/ApiListingUtil.scala
+++ b/src/main/scala/com/knappsack/swagger4springweb/util/ApiListingUtil.scala
@@ -8,4 +8,5 @@ import com.wordnik.swagger.model.ApiListing
 object ApiListingUtil {
   def combine(main: ApiListing, additional : ApiListing) : ApiListing = main.copy(apis = main.apis ++ additional.apis)
   def sortApisByPath(obj: ApiListing) : ApiListing = obj.copy(apis = obj.apis.sortBy(api => api.path))
+  def changeDescription(obj: ApiListing, desc: String) : ApiListing = obj.copy(description = Some(desc))
 }

--- a/src/test/java/com/knappsack/swagger4springweb/AbstractTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/AbstractTest.java
@@ -1,14 +1,14 @@
 package com.knappsack.swagger4springweb;
 
-import com.wordnik.swagger.model.ApiInfo;
-
 import java.util.Arrays;
 import java.util.List;
+
+import com.wordnik.swagger.model.ApiInfo;
 
 public abstract class AbstractTest {
 
     public static final String BASE_CONTROLLER_PACKAGE = "com.knappsack.swagger4springweb.testController";
     public static final String EXCLUDE_LABEL = "exclude";
-    public static final List<String> END_POINT_PATHS = Arrays.asList("/doc/api/v1/partialExclude", "/doc/api/v1/test", "/doc/api/v1/exclude2", "/doc/com.knappsack.swagger4springweb.testController.NoClassLevelMappingController");
+    public static final List<String> END_POINT_PATHS = Arrays.asList("/doc/api/v1/partialExclude", "/doc/api/v1/test", "/doc/api/v1/exclude2", "/doc/com.knappsack.swagger4springweb.testController.NoClassLevelMappingController", "/doc/api/v1/nocolor", "/doc/dark", "/doc/light");
     public static final ApiInfo API_INFO = new ApiInfo("swagger4spring-web example app", "This is a basic web app for demonstrating swagger4spring-web", "http://localhost:8080/terms", "http://localhost:8080/contact", "MIT", "http://opensource.org/licenses/MIT");
 }

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -2,11 +2,14 @@ package com.knappsack.swagger4springweb;
 
 import com.knappsack.swagger4springweb.parser.ApiParser;
 import com.knappsack.swagger4springweb.parser.ApiParserImpl;
+import com.wordnik.swagger.model.ApiDescription;
 import com.wordnik.swagger.model.ApiListing;
 import junit.framework.*;
 import org.junit.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import scala.Function1;
+import scala.collection.Iterator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,9 +28,20 @@ public class ApiCategoryTest extends AbstractTest {
     ApiParser apiParser = createApiParser();
     Map<String, ApiListing> documents = apiParser.createApiListings();
 
-    assertEquals(2, documents.size());
+    assertEquals("api keys expected", 2, documents.size());
     assertTrue(documents.containsKey("dark"));
     assertTrue(documents.containsKey("light"));
+
+    scala.collection.immutable.List<ApiDescription> dark = documents.get("dark").apis();
+//    assertEquals("dark colors expected", 2, dark.size());
+
+    boolean foundBlack, foundBlue;
+    for (Iterator<ApiDescription> it = dark.iterator(); it.hasNext();) {
+      ApiDescription description = it.next();
+      description.path().equals("sky");
+      System.out.println(description.path());
+
+    }
 
   }
 

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -35,12 +35,13 @@ public class ApiCategoryTest extends AbstractTest {
     ApiListing darkApiListing = documents.get("/dark");
 
     scala.collection.immutable.List<ApiDescription> dark = darkApiListing.apis();
-    assertEquals("dark colors expected", 3, dark.size());
+    assertEquals("dark colors expected", 4, dark.size());
 
     // Validate alphabetic ordering
     assertTrue("earth should be first", dark.apply(0).path().equals("/api/v1/black/earth"));
-    assertTrue("x-planet should be second", dark.apply(1).path().equals("/api/v1/black/x-planet"));
-    assertTrue("sky should be third", dark.apply(2).path().equals("/api/v1/blue/sky"));
+    assertTrue("wildcard should be second", dark.apply(1).path().equals("/api/v1/black/wildcard"));
+    assertTrue("x-planet should be 3rd", dark.apply(2).path().equals("/api/v1/black/x-planet"));
+    assertTrue("sky should be 4th", dark.apply(3).path().equals("/api/v1/blue/sky"));
 
     assertEquals("This is so dark", darkApiListing.description().get());
 

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -14,6 +14,8 @@ import com.knappsack.swagger4springweb.parser.ApiParser;
 import com.knappsack.swagger4springweb.parser.ApiParserImpl;
 import com.wordnik.swagger.model.ApiDescription;
 import com.wordnik.swagger.model.ApiListing;
+import com.wordnik.swagger.model.ApiListingReference;
+import com.wordnik.swagger.model.ResourceListing;
 
 import scala.collection.Iterator;
 
@@ -26,15 +28,15 @@ public class ApiCategoryTest extends AbstractTest {
     ApiParser apiParser = createApiParser();
     Map<String, ApiListing> documents = apiParser.createApiListings();
 
-    assertEquals("api keys expected", 2, documents.size());
-    assertTrue(documents.containsKey("dark"));
-    assertTrue(documents.containsKey("light"));
+    assertEquals("api keys expected", 3, documents.size());
+    assertTrue(documents.containsKey("/dark"));
+    assertTrue(documents.containsKey("/light"));
 
-    scala.collection.immutable.List<ApiDescription> dark = documents.get("dark").apis();
+    scala.collection.immutable.List<ApiDescription> dark = documents.get("/dark").apis();
     assertEquals("dark colors expected", 2, dark.size());
 
     boolean foundBlack = false, foundBlue = false;
-    for (Iterator<ApiDescription> it = dark.iterator(); it.hasNext();) {
+    for (Iterator<ApiDescription> it = dark.iterator(); it.hasNext(); ) {
       ApiDescription description = it.next();
 
       if (description.operations().iterator().next().nickname().equals("sky")) {
@@ -50,14 +52,37 @@ public class ApiCategoryTest extends AbstractTest {
 
   }
 
+  @Test
+  public void resourceListing() {
+    ApiParser apiParser = createApiParser();
+    ResourceListing resourceListing = apiParser.getResourceListing(apiParser.createApiListings());
+    assertEquals(3, resourceListing.apis().size());
+    scala.collection.immutable.List<ApiListingReference> apis = resourceListing.apis();
+
+
+    boolean foundDark = false;
+    boolean foundLight = false;
+    boolean foundNoColor = false;
+    for (Iterator<ApiListingReference> it = apis.iterator(); it.hasNext(); ) {
+
+      ApiListingReference apiListingReference = it.next();
+      if (apiListingReference.path().equals("/doc/dark")) foundDark = true;
+      if (apiListingReference.path().equals("/doc/light")) foundLight = true;
+      if (apiListingReference.path().equals("/doc/api/v1/nocolor")) foundNoColor = true;
+    }
+    assertTrue("found dark category", foundDark);
+    assertTrue("found light category", foundLight);
+    assertTrue("found no color category", foundNoColor);
+  }
+
 
   private ApiParser createApiParser() {
-   return createApiParser(Arrays.asList(BASE_CONTROLLER_PACKAGE + ".category"));
+    return createApiParser(Arrays.asList(BASE_CONTROLLER_PACKAGE + ".category"));
   }
 
   private ApiParser createApiParser(List<String> controllerPackages) {
     return new ApiParserImpl(API_INFO, controllerPackages, "http://localhost:8080/api", "/api", "v1",
-      new ArrayList<String>(), true, null);
+        new ArrayList<String>(), true, null);
   }
 
 }

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -1,0 +1,44 @@
+package com.knappsack.swagger4springweb;
+
+import com.knappsack.swagger4springweb.parser.ApiParser;
+import com.knappsack.swagger4springweb.parser.ApiParserImpl;
+import com.wordnik.swagger.model.ApiListing;
+import junit.framework.*;
+import org.junit.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class ApiCategoryTest extends AbstractTest {
+
+  @Test
+  public void category() {
+
+    ApiParser apiParser = createApiParser();
+    Map<String, ApiListing> documents = apiParser.createApiListings();
+
+    assertEquals(2, documents.size());
+    assertTrue(documents.containsKey("dark"));
+    assertTrue(documents.containsKey("light"));
+
+  }
+
+
+  private ApiParser createApiParser() {
+   return createApiParser(Arrays.asList(BASE_CONTROLLER_PACKAGE + ".category"));
+  }
+
+  private ApiParser createApiParser(List<String> controllerPackages) {
+    return new ApiParserImpl(API_INFO, controllerPackages, "http://localhost:8080/api", "/api", "v1",
+      new ArrayList<String>(), true, null);
+  }
+
+}

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -32,7 +32,9 @@ public class ApiCategoryTest extends AbstractTest {
     assertTrue(documents.containsKey("/dark"));
     assertTrue(documents.containsKey("/light"));
 
-    scala.collection.immutable.List<ApiDescription> dark = documents.get("/dark").apis();
+    ApiListing darkApiListing = documents.get("/dark");
+
+    scala.collection.immutable.List<ApiDescription> dark = darkApiListing.apis();
     assertEquals("dark colors expected", 3, dark.size());
 
     // Validate alphabetic ordering
@@ -40,7 +42,7 @@ public class ApiCategoryTest extends AbstractTest {
     assertTrue("x-planet should be second", dark.apply(1).path().equals("/api/v1/black/x-planet"));
     assertTrue("sky should be third", dark.apply(2).path().equals("/api/v1/blue/sky"));
 
-    assertEquals("This is so dark", dark.apply(0).description().get());
+    assertEquals("This is so dark", darkApiListing.description().get());
 
   }
 

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -40,6 +40,8 @@ public class ApiCategoryTest extends AbstractTest {
     assertTrue("x-planet should be second", dark.apply(1).path().equals("/api/v1/black/x-planet"));
     assertTrue("sky should be third", dark.apply(2).path().equals("/api/v1/blue/sky"));
 
+    assertEquals("This is so dark", dark.apply(0).description().get());
+
   }
 
   @Test

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -33,22 +33,12 @@ public class ApiCategoryTest extends AbstractTest {
     assertTrue(documents.containsKey("/light"));
 
     scala.collection.immutable.List<ApiDescription> dark = documents.get("/dark").apis();
-    assertEquals("dark colors expected", 2, dark.size());
+    assertEquals("dark colors expected", 3, dark.size());
 
-    boolean foundBlack = false, foundBlue = false;
-    for (Iterator<ApiDescription> it = dark.iterator(); it.hasNext(); ) {
-      ApiDescription description = it.next();
-
-      if (description.operations().iterator().next().nickname().equals("sky")) {
-        foundBlue = true;
-      }
-      if (description.operations().iterator().next().nickname().equals("earth")) {
-        foundBlack = true;
-      }
-    }
-
-    assertTrue("found black", foundBlack);
-    assertTrue("found blue", foundBlue);
+    // Validate alphabetic ordering
+    assertTrue("earth should be first", dark.apply(0).path().equals("/api/v1/black/earth"));
+    assertTrue("x-planet should be second", dark.apply(1).path().equals("/api/v1/black/x-planet"));
+    assertTrue("sky should be third", dark.apply(2).path().equals("/api/v1/blue/sky"));
 
   }
 

--- a/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/ApiCategoryTest.java
@@ -1,23 +1,21 @@
 package com.knappsack.swagger4springweb;
 
-import com.knappsack.swagger4springweb.parser.ApiParser;
-import com.knappsack.swagger4springweb.parser.ApiParserImpl;
-import com.wordnik.swagger.model.ApiDescription;
-import com.wordnik.swagger.model.ApiListing;
-import junit.framework.*;
-import org.junit.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import scala.Function1;
-import scala.collection.Iterator;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.knappsack.swagger4springweb.parser.ApiParser;
+import com.knappsack.swagger4springweb.parser.ApiParserImpl;
+import com.wordnik.swagger.model.ApiDescription;
+import com.wordnik.swagger.model.ApiListing;
+
+import scala.collection.Iterator;
 
 
 public class ApiCategoryTest extends AbstractTest {
@@ -33,15 +31,22 @@ public class ApiCategoryTest extends AbstractTest {
     assertTrue(documents.containsKey("light"));
 
     scala.collection.immutable.List<ApiDescription> dark = documents.get("dark").apis();
-//    assertEquals("dark colors expected", 2, dark.size());
+    assertEquals("dark colors expected", 2, dark.size());
 
-    boolean foundBlack, foundBlue;
+    boolean foundBlack = false, foundBlue = false;
     for (Iterator<ApiDescription> it = dark.iterator(); it.hasNext();) {
       ApiDescription description = it.next();
-      description.path().equals("sky");
-      System.out.println(description.path());
 
+      if (description.operations().iterator().next().nickname().equals("sky")) {
+        foundBlue = true;
+      }
+      if (description.operations().iterator().next().nickname().equals("earth")) {
+        foundBlack = true;
+      }
     }
+
+    assertTrue("found black", foundBlack);
+    assertTrue("found blue", foundBlue);
 
   }
 

--- a/src/test/java/com/knappsack/swagger4springweb/controller/ApiDocumentationControllerTest.java
+++ b/src/test/java/com/knappsack/swagger4springweb/controller/ApiDocumentationControllerTest.java
@@ -1,15 +1,18 @@
 package com.knappsack.swagger4springweb.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.HandlerMapping;
+
 import com.knappsack.swagger4springweb.AbstractTest;
 import com.knappsack.swagger4springweb.util.ScalaToJavaUtil;
 import com.wordnik.swagger.model.ApiListing;
 import com.wordnik.swagger.model.ApiListingReference;
 import com.wordnik.swagger.model.ResourceListing;
-import org.junit.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.servlet.HandlerMapping;
-
-import static org.junit.Assert.*;
 
 public class ApiDocumentationControllerTest extends AbstractTest {
 
@@ -41,7 +44,6 @@ public class ApiDocumentationControllerTest extends AbstractTest {
         assertNotNull(documentation);
         assertEquals("v1", documentation.apiVersion());
         assertEquals(END_POINT_PATHS.size(), documentation.apis().size());
-        assertEquals("/doc/api/v1/test", documentation.apis().apply(0).path());
 
         for (ApiListingReference endPoint : ScalaToJavaUtil.toJavaList(documentation.apis())) {
             assertTrue(END_POINT_PATHS.contains(endPoint.path()));

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
@@ -1,7 +1,10 @@
 package com.knappsack.swagger4springweb.testController.category;
 
 
+import static java.util.Arrays.asList;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import java.util.List;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,4 +27,11 @@ public class BlackController {
   public String earth() {
     return "earth";
   }
+
+  @ApiOperation("Wildcard list")
+  @RequestMapping(value = "/wildcard", method = GET)
+  public List<? extends Number> genericType() {
+    return asList(6L, 4L);
+  }
+
 }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
@@ -6,12 +6,11 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
 import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/black")
-@ApiCategory("dark")
+@DarkCategory
 public class BlackController {
 
   @ApiOperation("This is for testing ordering")

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
@@ -1,0 +1,24 @@
+package com.knappsack.swagger4springweb.testController.category;
+
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.knappsack.swagger4springweb.annotation.ApiExclude;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@Controller
+@RequestMapping("/api/v1/black")
+@Api(value = "Test Category, black")
+@ApiCategory("dark")
+public class BlackController {
+
+  @ApiOperation("Black is earth")
+  @RequestMapping(value = "earth", method = GET)
+  public String earth() {
+    return "earth";
+  }
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
@@ -14,6 +14,12 @@ import com.wordnik.swagger.annotations.ApiOperation;
 @ApiCategory("dark")
 public class BlackController {
 
+  @ApiOperation("This is for testing ordering")
+  @RequestMapping(value = "/x-planet", method = GET)
+  public String xPlanet() {
+    return "x-planet";
+  }
+
   @ApiOperation("Black is earth")
   @RequestMapping(value = "/earth", method = GET)
   public String earth() {

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlackController.java
@@ -1,23 +1,21 @@
 package com.knappsack.swagger4springweb.testController.category;
 
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
-import com.knappsack.swagger4springweb.annotation.ApiExclude;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/black")
-@Api(value = "Test Category, black")
 @ApiCategory("dark")
 public class BlackController {
 
   @ApiOperation("Black is earth")
-  @RequestMapping(value = "earth", method = GET)
+  @RequestMapping(value = "/earth", method = GET)
   public String earth() {
     return "earth";
   }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlueController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlueController.java
@@ -5,14 +5,13 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/blue")
 @Api(value = "/api/v1/blue", description = "Test Category, blue") // this will be ignored due to @ApiCategory
-@ApiCategory("dark")
+@DarkCategory
 public class BlueController {
 
   @ApiOperation("Blue is sky")

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlueController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlueController.java
@@ -1,16 +1,17 @@
 package com.knappsack.swagger4springweb.testController.category;
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/blue")
-@Api(value = "Test Category, blue")
+@Api(value = "/api/v1/blue", description = "Test Category, blue") // this will be ignored due to @ApiCategory
 @ApiCategory("dark")
 public class BlueController {
 

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/BlueController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/BlueController.java
@@ -1,0 +1,22 @@
+package com.knappsack.swagger4springweb.testController.category;
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@Controller
+@RequestMapping("/api/v1/blue")
+@Api(value = "Test Category, blue")
+@ApiCategory("dark")
+public class BlueController {
+
+  @ApiOperation("Blue is sky")
+  @RequestMapping(value = "/sky", method = GET)
+  public String sky() {
+    return "sky";
+  }
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/DarkCategory.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/DarkCategory.java
@@ -1,0 +1,18 @@
+package com.knappsack.swagger4springweb.testController.category;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+
+/**
+ * @author Allar Tammik
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ApiCategory(value = "dark", description = "This is so dark")
+public @interface DarkCategory {
+  String value() default "";
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/DarkCategory.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/DarkCategory.java
@@ -14,5 +14,4 @@ import com.knappsack.swagger4springweb.annotation.ApiCategory;
 @Target(ElementType.TYPE)
 @ApiCategory(value = "dark", description = "This is so dark")
 public @interface DarkCategory {
-  String value() default "";
 }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/LightCategory.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/LightCategory.java
@@ -14,5 +14,4 @@ import com.knappsack.swagger4springweb.annotation.ApiCategory;
 @Target(ElementType.TYPE)
 @ApiCategory(value = "light", description = "This is so bright")
 public @interface LightCategory {
-  String value() default "";
 }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/LightCategory.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/LightCategory.java
@@ -1,0 +1,18 @@
+package com.knappsack.swagger4springweb.testController.category;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+
+/**
+ * @author Allar Tammik
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ApiCategory(value = "light", description = "This is so bright")
+public @interface LightCategory {
+  String value() default "";
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/NoColorController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/NoColorController.java
@@ -1,19 +1,21 @@
 package com.knappsack.swagger4springweb.testController.category;
 
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
-import com.wordnik.swagger.annotations.Api;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/nocolor")
-@Api(value = "Test Category, this controller does not have ApiCategory annotation, thus will be mapped as earlier")
+@Api(value = "/api/v1/nocolor", description = "Test Category, this controller does not have ApiCategory annotation, thus will be mapped as earlier")
 public class NoColorController {
 
   @RequestMapping(value = "/invisible", method = GET)
+  @ApiOperation("I am invisible")
   public String invisible() {
     return "invisible";
   }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/NoColorController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/NoColorController.java
@@ -1,0 +1,20 @@
+package com.knappsack.swagger4springweb.testController.category;
+
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.wordnik.swagger.annotations.Api;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@Controller
+@RequestMapping("/api/v1/nocolor")
+@Api(value = "Test Category, this controller does not have ApiCategory annotation, thus will be mapped as earlier")
+public class NoColorController {
+
+  @RequestMapping(value = "/invisible", method = GET)
+  public String invisible() {
+    return "invisible";
+  }
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
@@ -1,12 +1,13 @@
 package com.knappsack.swagger4springweb.testController.category;
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/white")
@@ -15,7 +16,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 public class WhiteController {
 
   @ApiOperation("White is fortune")
-  @RequestMapping(value = "fortune", method = GET)
+  @RequestMapping(value = "/fortune", method = GET)
   public String fortune() {
     return "fortune";
   }

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
@@ -5,14 +5,13 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.knappsack.swagger4springweb.annotation.ApiCategory;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/white")
 @Api(value = "/api/v1/white",description = "Test Category, white")
-@ApiCategory("light")
+@LightCategory
 public class WhiteController {
 
   @ApiOperation("White is fortune")

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
@@ -1,0 +1,22 @@
+package com.knappsack.swagger4springweb.testController.category;
+
+import com.knappsack.swagger4springweb.annotation.ApiCategory;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@Controller
+@RequestMapping("/api/v1/white")
+@Api(value = "Test Category, white")
+@ApiCategory("light")
+public class WhiteController {
+
+  @ApiOperation("White is fortune")
+  @RequestMapping(value = "fortune", method = GET)
+  public String fortune() {
+    return "fortune";
+  }
+}

--- a/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
+++ b/src/test/java/com/knappsack/swagger4springweb/testController/category/WhiteController.java
@@ -11,7 +11,7 @@ import com.wordnik.swagger.annotations.ApiOperation;
 
 @Controller
 @RequestMapping("/api/v1/white")
-@Api(value = "Test Category, white")
+@Api(value = "/api/v1/white",description = "Test Category, white")
 @ApiCategory("light")
 public class WhiteController {
 


### PR DESCRIPTION
Hi

I'm sending a pull request.
This modification is driven by growing amount of controllers in our application. To make swagger more easily readable, we wanted to group them somehow. So we introduced categories to this API.

In detail, now you can group multiple controllers together into a 'category' using ApiCategory annotation. Feature is fully tested and we are using it in production.
We also added default alphabetic sorting of paths (if order is not explicitly given).
